### PR TITLE
semicolons and handle 404 with content with grace

### DIFF
--- a/src/angular-model.js
+++ b/src/angular-model.js
@@ -236,7 +236,7 @@ angular.module('ur.model', []).provider('model', function() {
 
         return {
           get: function() { return parsed(obj); },
-          set: function(value) { return parsed.assign(obj, value); }
+          set: function(value) { return parsed.assign(obj || {}, value); }
         };
       };
 

--- a/test/modelSpec.js
+++ b/test/modelSpec.js
@@ -295,6 +295,14 @@ describe("model", function() {
         expect(response.status).toBe(422);
         expect(JSON.stringify(user.$errors)).toEqual(JSON.stringify(errors));
       }));
+
+      it("should handle a failed request to GET all", inject(function(model) {
+        $httpBackend.expectGET('http://api/users').respond(404, []);
+
+        users = model('Users').all();
+
+        $httpBackend.flush();
+      }));
     });
   });
 });


### PR DESCRIPTION
First commit adds some semicolons because jslint was bugging me about them.

Second commit attempts to address `TypeError: 'null' is not an object (evaluating 'obj[element.shift()] = setValue')`, which occurs if a request initiated with model.all() gets a response with status 404 and body a non-empty string.

It may not be the 'correct' fix, but raising the PR anyway to at least provide a test case to reproduce the issue.
