### PR TITLE
Naive implementation of array clone

### DIFF
--- a/src/angular-model.js
+++ b/src/angular-model.js
@@ -11,15 +11,34 @@ var noop   = angular.noop,
   isUndef  = angular.isUndefined,
   equals   = angular.equals;
 
+
+function lisObject(thing) {
+  return thing.constructor && thing.constructor === Object;
+}
+
 function deepExtend(dst, source) {
   for (var prop in source) {
-    if (source[prop] && source[prop].constructor && source[prop].constructor === Object) {
+    if (source[prop] && lisObject(source[prop])) {
       dst[prop] = dst[prop] || {};
 
-      if (dst[prop].constructor && dst[prop].constructor === Object) {
+      if (lisObject(dst[prop])) {
         deepExtend(dst[prop], source[prop]);
         continue;
       }
+    }
+    else if(isArray(source[prop])) {
+      dst[prop] = [];
+      for (var i = 0; i < source[prop].length; i++) {
+        var item = source[prop][i];
+        if (lisObject(item)) {
+          dst[prop].push(deepExtend({}, item));
+        } else if(isArray(item)) {
+          dst[prop].push(deepExtend([], item));
+        } else {
+          dst[prop].push(source[prop][i]);
+        }
+      }
+      continue;
     }
     dst[prop] = source[prop];
   }

--- a/test/modelSpec.js
+++ b/test/modelSpec.js
@@ -534,7 +534,7 @@ describe("model", function() {
         list.$save();
 
         $httpBackend.expectPOST('http://api/tasks', {
-          things: [],
+          things: []
         }).respond(201, {
           things: [],
           $links: { self: "http://api/tasks/1138" }
@@ -546,8 +546,10 @@ describe("model", function() {
         list.$save();
 
         $httpBackend.expectPATCH('http://api/tasks/1138', {
-          things: ['foo', 'bar'],
-        }).respond(200);
+          things: ['foo', 'bar']
+        }).respond(200, {
+          things: ['foo', 'bar']
+        });
 
         $httpBackend.flush();
 
@@ -559,8 +561,10 @@ describe("model", function() {
         list.$save();
 
         $httpBackend.expectPATCH('http://api/tasks/1138', {
-          things: ['foo'],
-        }).respond(200);
+          things: ['foo']
+        }).respond(200, {
+          things: ['foo']
+        });
 
         $httpBackend.flush();
 


### PR DESCRIPTION
`deepExtend` was unable to correctly clone arrays. This resulted in `original` storing a reference to an array rather than a deep copy. Therefore, the pristine check would always return 'true', even without sync being called on the `ModelInstance`.

Also alter the PATCH calls in the test so they return the expected version of the updated object.
