### PR TITLE
Skip PATCH immediately when saving unmodified instances

### DIFF
--- a/src/angular-model.js
+++ b/src/angular-model.js
@@ -172,6 +172,10 @@ angular.module('ur.model', []).provider('model', function() {
           requestData = deepExtend(this, data ? copy(data) : {});
         }
 
+        if (equals({}, requestData)) {
+          return q.when(this);
+        }
+
         return $request(this, this.$model(), method, requestData);
       },
       $delete: function() {
@@ -355,7 +359,7 @@ angular.module('ur.model', []).provider('model', function() {
     this.$original = function() { return original; };
     this.$original.sync = function(data) {
       original = deepExtend(original, data);
-    }
+    };
   }
 
 }).directive('link', ['model', function(model) {

--- a/test/modelSpec.js
+++ b/test/modelSpec.js
@@ -16,7 +16,7 @@ describe("model", function() {
         };
       }
     });
-  })
+  });
 
   describe("provider", function() {
 
@@ -300,7 +300,7 @@ describe("model", function() {
 
         user = model('Users').create({ $links: { self: id }});
 
-        user.$save().then(angular.noop, function(resp) {
+        user.$save({name: 'test'}).then(angular.noop, function(resp) {
           response = resp;
         });
         expect(user.$errors).toBeUndefined();
@@ -511,6 +511,14 @@ describe("model", function() {
             home: "0123"
           }
         });
+      });
+
+      it('should skip PATCH for an umodified instance and resolve immediately', function() {
+        user.$save().then(function(resp) {
+          expect(resp).toEqualData(user);
+        });
+
+        $httpBackend.verifyNoOutstandingRequest();
       });
 
       it('should ignore dirty fields when saving a new instance', inject(function(model) {


### PR DESCRIPTION
Returns an immediately resolved promise to make consuming logic think
that a successful save occurred.
