### PR TITLE
Allow string parameters to be considered as id to build a view query url using first().

### DIFF
--- a/src/angular-model.js
+++ b/src/angular-model.js
@@ -251,8 +251,16 @@ angular.module('ur.model', []).provider('model', function() {
       headers: headers
     };
 
-    if (!isWrite && isObject(data) && !isEmpty(data)) {
-      params.url += (params.url.indexOf('?') > -1 ? '&' : '?') + serialize(data);
+    if (!isWrite && !isEmpty(data)) {
+      if(isObject(data)) {
+        // index url: resources?<params>
+        params.url += (params.url.indexOf('?') > -1 ? '&' : '?') + serialize(data);
+      } else {
+        // view url: resources/<id>
+        var parts = params.url.split('?');
+        parts[1] = parts.length > 1 ? '?' + parts[1] : '';
+        params.url = parts[0] + '/' + data.toString() + parts[1];
+      }
     }
 
     return extend(deferred.promise, {

--- a/test/modelSpec.js
+++ b/test/modelSpec.js
@@ -307,7 +307,7 @@ describe("model", function() {
             { name: "Second Project", $links: { self: { href: "http://api/projects/1139" }}}
           ];
           $httpBackend.expectGET("http://api/projects").respond(200, JSON.stringify(data));
-    
+
           model("Projects").first().then(function(result) {
             expect(result.name).toBe("First Project");
           });
@@ -317,7 +317,7 @@ describe("model", function() {
         it("should return the full result of non-array responses", inject(function(model) {
           var data = { name: "A Project", $links: { self: { href: "http://api/projects/a" }}};
           $httpBackend.expectGET("http://api/projects").respond(200, JSON.stringify(data));
-    
+
           model("Projects").first().then(function(result) {
             expect(result.name).toBe("A Project");
             expect(result.$links.self.href).toBe("http://api/projects/a");
@@ -336,6 +336,22 @@ describe("model", function() {
 
           expect(first.name).toBe("First Project");
           expect(first.$links.self.href).toBe("http://api/projects/first");
+        }));
+
+        it("should generate a view query if the parameter is not an object", inject(function(model) {
+          var abc;
+          $httpBackend.expectGET("http://api/projects/abc").respond(200, JSON.stringify({
+            name: "Abc Project",
+            $links: { self: { href : "http://api/projects/abc" } }
+          }));
+
+          model("Projects").first('abc').then(function(result) {
+            abc = result;
+          });
+          $httpBackend.flush();
+
+          expect(abc.name).toBe("Abc Project");
+          expect(abc.$links.self.href).toBe("http://api/projects/abc");
         }));
       });
     });


### PR DESCRIPTION
When a page is loaded and the url parsed for the first time, we don't have any reference of the resource url (i.e the $links data).

Using:
```js
model('Resources').first({ id: 'myid' })
```

To get the data back, will generate a //api/resources?id=myid url

However index calls is also used to get a lot of datas and this become problematic when we want to embed all the stuff inside an index call.

this PR allow the following syntax

```js
model('Resources').first('myid')
```

which will generate a //api/resources/myid url

This way we differenciate what should be returned by an index call (i.e. the minmum) and what is returned by a view call (the whole document with embeded datas)