### PR TITLE
Integrates CodeClimate with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,7 @@ before_script:
 
 script:
   - gulp
+
+addons:
+    code_climate:
+        repo_token: $CODECLIMATE_REPO_TOKEN


### PR DESCRIPTION
Integrates CodeClimate with Travis
--

* This is not hugely important, but it will adds more info to our CodeClimate page. 
* Once CodeClimate gets their test coverage metric up to snuff--and that might be a ways off--I'd like to replace Coveralls test coverage with CodeClimate. 