### PR TITLE
Temporarily disables gulp security task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -50,5 +50,5 @@ gulp.task('security', function(cb) {
 });
 
 gulp.task('default', function(cb) {
-  runSequence('test', ['lint', 'style', 'coveralls', 'security'], cb);
+  runSequence('test', ['lint', 'style', 'coveralls'], cb);
 });


### PR DESCRIPTION
* The security package, `gulp-requireSafe`, has been deprecated.
* `gulp-nsp` is its replacement. However, it does not yet work
  due to a bug.
* This PR disables the security task.
* I will reactivate the security task once `gulp-nsp` gets
  their house in order.