### PR TITLE
Fixes gulp security task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var gulp      = require('gulp');
-var Server    = require('karma').Server;
-var coveralls = require('gulp-coveralls');
-var jshint    = require('gulp-jshint');
-var jscs      = require('gulp-jscs');
+var gulp        = require('gulp');
+var Server      = require('karma').Server;
+var coveralls   = require('gulp-coveralls');
+var jshint      = require('gulp-jshint');
+var jscs        = require('gulp-jscs');
+var nsp         = require('gulp-nsp');
 var runSequence = require('run-sequence');
-var gulpRequireSafe = require('gulp-requiresafe');
 
 /*
  * PLEASE NOTE: run-sequence is a
@@ -46,9 +46,12 @@ gulp.task('style', function() {
 });
 
 gulp.task('security', function(cb) {
-  gulpRequireSafe({package: __dirname + '/package.json', stopOnError: true}, cb);
+  nsp({
+    package: __dirname + '/package.json',
+    stopOnError: true
+  }, cb);
 });
 
 gulp.task('default', function(cb) {
-  runSequence('test', ['lint', 'style', 'coveralls'], cb);
+  runSequence('test', ['lint', 'style', 'coveralls', 'security'], cb);
 });

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-coveralls": "^0.1.4",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^1.12.0",
+    "gulp-nsp": "^2.0.1",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.14",
     "karma-coverage": "^0.5.3",
@@ -43,9 +44,7 @@
     "phantomjs": "^1.9.18",
     "run-sequence": "^1.1.4"
   },
-  "dependencies": {
-    "gulp-requiresafe": "^1.1.2"
-  },
+  "dependencies": {},
   "keywords": [
     "angular",
     "angularjs",


### PR DESCRIPTION
Fixes gulp security task
--

* Replaces the now-deprecated requireSafe with gulp-nsp
* Restores security task to gulp default task
* Minor formatting cleanup
* Closes issue #41. 