### PR TITLE
Automates NPM publication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ before_script:
 script:
   - gulp
 
+deploy:
+  provider: npm
+  email: "john@radify.io"
+  api_key:
+    secure: "KP2ktSoNArc01Fvt9/4feIggTA8UxbnH64zMBPiQcKTMlkNCqwDOeeMA+os/fb7Yz1yZ9pRSM+MoUcphav3ykLTN+PqMiQ7BUpo9HMh58zH9SxvtP3LAn1hQOO3tarBfiVb8flrloyrXxrhKPXkYJckTPoJF/fx8ZzId0qMHbj4WhVx1Y1pGZdtqbEb8EJfHIs69e4AZLK3P2KA41omPyH+jhEbbC9MozKX0Z23SwmJQHqgUEipbYG0bAILD/A+j4C7LgHvh8wuqLu1XZfWkozJjNGqqOjcb1M6yaB90NzbBLhXDXjwHA+Fke5IaCfNY4F6FSqtYcgPf2BWQ0S4Pp9BvtD4e/qmDP7XYqiMIeGBuy/t8qT/rg3WX/nScCfSocDH1/+/5Zd78jdUYeFwVguPvihgfNFxNflCxg1Kzq09CuzvjAx/oc7PFm2GeDwq204+VFdQsOBSPJwEmlbSfozbRRtlSYQ4yPeA5Yw3o97V0kd7ZIG3r4GcyuMsSpMgfXv7GBNI4y5DDefnfJU0iLNiWJ21WatiUNLTxM1PRFfuMy05I22rwjYY5YQMEAi42/yQKhDABLk7rXjgpo7OML15ppxBswX8chV5ltGy+vKmtCAr7MCHo6PnK/Pj0g6aXYSwjnZhG391hZhJkn0LNLJzpD592na6zJEHYjpcf/VU="
+  on:
+    tags: true
+    branch: master
+
 addons:
   code_climate:
     repo_token:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+## [0.6.1] - 2015-11-25
+### Added
+- Automates NPM publication
+
 ## [0.6.0] - 2015-11-19
 ### Added
 - Significantly increases documentation
@@ -49,6 +55,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - CHANGELOG
 
-[Unreleased]: https://github.com/radify/angular-model/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/radify/angular-model/compare/v0.4.1...v0.5.0
-[0.4.1]: https://github.com/radify/angular-model/compare/v0.4.0...v0.4.1
+[Unreleased]: https://github.com/radify/angular-model/compare/0.6.1...HEAD
+[0.6.1]: https://github.com/radify/angular-model/compare/0.6.0...0.6.1
+[0.6.0]: https://github.com/radify/angular-model/compare/0.5.0...0.6.0
+[0.5.0]: https://github.com/radify/angular-model/compare/0.4.1...0.5.0
+[0.4.1]: https://github.com/radify/angular-model/compare/0.4...0.4.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-model",
   "description": "Simple HATEOS-oriented persistence module for AngularJS.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "BSD-3-Clause",
   "maintainers": [
     {


### PR DESCRIPTION
Automates NPM publication
--

### Description

* automates NPM publication
* updates CHANGELOG for new release
* fixes CHANGELOG formatting
* sets new release: 0.6.1

### Test Script

* None. CI must pass. 
* Note: the new version will not be published until I update the tag on Github, which I'll do as soon as this PR is merged.