### PR TITLE
Sets travis to use current infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "0.11"


### PR DESCRIPTION
Sets travis to use current infrastructure
--

### Description

* `sudo: false` tells Travis to use its current container-based infrastructure rather than its legacy infrastructure

### Test Script

* None